### PR TITLE
Data ophalen & weergeven van Directus Api

### DIFF
--- a/src/lib/fetch-json.js
+++ b/src/lib/fetch-json.js
@@ -1,0 +1,20 @@
+/**
+ * An asynchronous helper function that wraps the standard node.js fetch API.
+ * This function calls an API url passed as the first and mandatory parameter,
+ * there is an optional payload parameter to send a json object, eg. a filter.
+ * It then calls the API and returns the response body parsed  as a json object.
+ * @example <caption>fetchJson as returning function using the await keyword</caption>
+ * const data = await fetchJson('https://api-url.com/endpoint/')
+ * @example <caption>fetchJson as oneliner using the then() structure.</caption>
+ * fetchJson('https://api-url.com/endpoint/').then((data)=>{
+ *  // use data...
+ * })
+ * @param {string} url the api endpoint to address
+ * @param {object} [payload] the payload to send to the API
+ * @returns the response from the API endpoint parsed as a json object
+ */
+export default async function fetchJson(url, payload = {}) {
+    return await fetch(url, payload)
+      .then((response) => response.json())
+      .catch((error) => error)
+  }

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,0 +1,14 @@
+// Ik heb eerst de fetchjson helper functie geimporteerd
+// Deze gebruik ik om een functie te maken die de data van de api ophaalt
+// De fetchJson functie wordt aangeroepen met de url van de api
+// De data die terugkomt wordt in een object gestopt en gereturnd
+// Dit object bevat de data van de api
+import fetchJson from "../lib/fetch-json";
+
+export async function load(){
+    const url = 'https://fdnd-agency.directus.app/items/fabrique_art_objects';
+    const response = await fetchJson(url);
+    return {
+        artObjects: response.data
+    };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,14 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<script>
+    export let data;
+    console.log(data); // Hiermee kun je zien hoe de API-respons eruitziet
+</script>
+
+{#each data.artObjects as art}
+    <ul>
+        <li>
+            <h2>{art.title}</h2>
+            <img src={"https://fdnd-agency.directus.app/assets/" + art.image} alt={art.title} />
+        </li>
+    </ul>
+{/each}
+


### PR DESCRIPTION
## ` 01-10-2024`
In deze PR heb ik de functionaliteit geimplementeerd om kunstobjecten op te halen via de Directus API en deze weer te geven op de pagina.

### `veranderingen:`
- Toevoegen van een helper functie `fetchJson` om API verzoeken te doen
- Implementatie van de` load functie `in de `+page.server.js `om data op te halen van: https://fdnd-agency.directus.app/items/fabrique_art_objects
- Weergave van de kunstobjecten in `+page.svelte`, incl titels en images.

### `Testen`
- Ik heb de API-respons gelogd om te controleren of de data correct werd opgehaald
<img width="800" alt="Scherm­afbeelding 2024-10-02 om 00 13 39" src="https://github.com/user-attachments/assets/59ba6cc4-de53-4918-9bba-030071d4ecc7">

- Ik kon de afbeeldingen niet zien, nu worden ze correct weergegeven door de bestands ID's te combineren met de Directus bestands URL.
<img width="800" alt="Scherm­afbeelding 2024-10-02 om 00 17 20" src="https://github.com/user-attachments/assets/c0d9665f-7995-4ff8-b855-0a2d6df6b71d">
